### PR TITLE
Coin market cap api deprecation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 [devel]
 
+[0.1.9]
+Updated to use CoinMarketCap's new API.
+
 [0.1.8]
 Updated support:appcompat and support:design to 27.1.1.
 Fixed crash when opening settings on Android versions.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.github.hintofbasil.hodl"
         minSdkVersion 15
         targetSdkVersion 27
-        versionCode 11
-        versionName "0.1.8"
+        versionCode 12
+        versionName "0.1.9"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/github/hintofbasil/hodl/database/CoinMarketCapUpdaterService.java
+++ b/app/src/main/java/com/github/hintofbasil/hodl/database/CoinMarketCapUpdaterService.java
@@ -28,8 +28,7 @@ import retrofit2.http.GET;
 
 public class CoinMarketCapUpdaterService extends IntentService {
 
-    public static final String BASE_URL = "https://api.coinmarketcap.com";
-    public static final String COIN_MARKET_CAP_API_URL = "https://api.coinmarketcap.com/v1/ticker/?limit=0";
+    public static final String BASE_URL = "http://fixer-io-cache.s3-website-eu-west-1.amazonaws.com";
 
     public static final String STATUS_FAILURE = "COIN_MARKET_CAP_UPDATER_STATUS_FAILURE";
     public static final String STATUS_COMPLETED = "COIN_MARKET_CAP_STATUS_COMPLETED";
@@ -155,7 +154,7 @@ public class CoinMarketCapUpdaterService extends IntentService {
     }
 
     public interface API {
-        @GET("/v1/ticker/?limit=0")
+        @GET("coin_market_cap_latest.json")
         Call<List<CoinSummaryGson>> getAll();
     }
 

--- a/lambdas/coin_market_cap_cache.py
+++ b/lambdas/coin_market_cap_cache.py
@@ -1,0 +1,49 @@
+"""
+A AWS lambda to gather data on all CoinMarketCap coins
+and format it so the app can easily injest it
+"""
+
+import boto3
+import json
+from botocore.vendored import requests
+
+URL = 'https://api.coinmarketcap.com/v2/ticker/?start={}&limit={}&sort=id&structure=array'
+s3 = boto3.resource('s3')
+
+def get_single_response(index):
+    start = index * 100
+    limit = 100
+    url = URL.format(start, limit)
+    response = requests.get(url)
+    return json.loads(response.text)['data']
+
+def get_all_coins():
+    coin_list = []
+    for i in range(100):
+        coin_sub_list = get_single_response(i)
+        if not coin_sub_list:
+            break
+        coin_sub_list = list(map(lambda x: flatten_coin(x), coin_sub_list))
+        coin_list = coin_list + coin_sub_list
+    return coin_list
+
+def flatten_coin(data):
+    flattened = {}
+    flattened['id'] = data['website_slug']
+    flattened['name'] = data['name']
+    flattened['symbol'] = data['symbol']
+    flattened['rank'] = str(data['rank'])
+    flattened['price_usd'] = str(data['quotes']['USD']['price'])
+    return flattened
+
+def write_file(data):
+    return s3.Bucket('fixer-io-cache').Object('coin_market_cap_latest.json').put(Body=data).update()
+
+def lambda_handler(event, context):
+    coins = get_all_coins()
+    coins = json.dumps(coins)
+    write_file(coins)
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Success')
+    }


### PR DESCRIPTION
A fix for https://github.com/hintofbasil/Hodl/issues/21.

A lambda consumes the new API and produces data matching the old API format.
This allows the app to update the URL only.